### PR TITLE
Fix: image snap to right edge in Chrome

### DIFF
--- a/scripts/Generic Image Viewer.user.js
+++ b/scripts/Generic Image Viewer.user.js
@@ -753,6 +753,8 @@ var ControlHQ =
             h = img.clientHeight;
         console.log(w / h, h / w);
         img.style.position = "absolute";
+        img.style.left = 0;
+        img.style.top = 0;
         if (reverse)
         {
             var offsetW = ((h - w) / 2);


### PR DESCRIPTION
When viewing an image smaller than window size, it will be positioned at the right most edge since it  has an initial position set by browser. We need to clear that position beforehand.